### PR TITLE
fix: package with no-git-checks option

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -44,7 +44,7 @@ jobs:
           echo "@solinkcorp:registry=https://npm.pkg.github.com/" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}" >> .npmrc
       - name: Publish Package
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Details
We're OK publishing with an unclean working tree during GitHub build.  Fixes this error:
` ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.
`